### PR TITLE
Remove extra comma from netkan

### DIFF
--- a/KerbalSports.netkan
+++ b/KerbalSports.netkan
@@ -17,7 +17,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/135728-/",
         "bugtracker": "https://github.com/jrossignol/KerbalSports/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/KerbalSports/master/GameData/KerbalSports/LICENSE.txt",
+        "license": "https://raw.githubusercontent.com/jrossignol/KerbalSports/master/GameData/KerbalSports/LICENSE.txt"
     }
 }
 


### PR DESCRIPTION
I was prototyping a stats gathering script (details unimportant here), and I got an error message pointing out a syntax error in this file. Currently the CKAN bot itself is not complaining about this, but I don't know whether that's because it's working around the problem or failing so completely that no error message is preserved. Either way, might as well fix it.